### PR TITLE
Correct missing s3MessageKey for setting S3 object

### DIFF
--- a/src/ExtendedSqsClient.js
+++ b/src/ExtendedSqsClient.js
@@ -249,6 +249,7 @@ class ExtendedSqsClient {
         let s3MessageKey;
 
         if (!sendObj.s3Content || existingS3MessageKey) {
+            s3MessageKey = existingS3MessageKey
             sendParams.MessageBody = sendObj.messageBody || existingS3MessageKey.StringValue;
         } else {
             s3MessageKey = uuidv4();


### PR DESCRIPTION
Hi, thank you for developing this lib.

I have tried to use a custom S3 message key instead of the UUID, but encountered an issue where the message object was not generated within the message bucket. I saw that the `s3MessageKey` did not get updated when an `existingS3MessageKey` was provided. Thus creating this PR.