### PR TITLE
Compatibility with Amazon SQS Extended Client Library for Java

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ The SQS Extended Client supports the following options:
 * `messageSizeThreshold` - maximum size in bytes for message payloads before they are stored in S3 (default: `262144`)
 * `sendTransform` - see _Transforms_ section
 * `receiveTransform` - see _Transforms_ section
+* `compatibleMode` - If true, use messsage body and attributes compatible with SQS Extended Client for Java
+* `use_legacy_attribute` - Applies to compatible mode only - if True, all published messages use the Legacy reserved message attribute (SQSLargePayloadSize) instead of the current reserved message attribute (ExtendedPayloadSize).
 
 Note that the use of transforms overrides the `alwaysUseS3` and `messageSizeThreshold` options.
 

--- a/src/ExtendedSqsClient.js
+++ b/src/ExtendedSqsClient.js
@@ -16,6 +16,8 @@ const { isLarge } = require('./sqsMessageSizeUtils');
 const S3_MESSAGE_KEY_MARKER = '-..s3Key..-';
 const S3_BUCKET_NAME_MARKER = '-..s3BucketName..-';
 const S3_MESSAGE_BODY_KEY = 'S3MessageBodyKey';
+const COMPATIBLE_ATTRIBUTE_NAME = "ExtendedPayloadSize";
+const COMPATIBLE_ATTRIBUTE_NAME_LEGACY = "SQSLargePayloadSize";
 
 function defaultSendTransform(alwaysUseS3, messageSizeThreshold) {
     return (message) => {
@@ -32,28 +34,48 @@ function defaultReceiveTransform() {
     return (message, s3Content) => s3Content || message.body || message.Body;
 }
 
-function getS3MessageKeyAndBucket(message) {
+function getS3MessageKeyAndBucket(message, compatibleMode) {
     const messageAttributes = message.messageAttributes || message.MessageAttributes || {};
 
-    if (!messageAttributes[S3_MESSAGE_BODY_KEY]) {
+    if (messageAttributes[S3_MESSAGE_BODY_KEY]) {
+        const s3MessageKeyAttr = messageAttributes[S3_MESSAGE_BODY_KEY];
+        const s3MessageKey = s3MessageKeyAttr.stringValue || s3MessageKeyAttr.StringValue;
+
+        if (!s3MessageKey) {
+            throw new Error(`Invalid ${S3_MESSAGE_BODY_KEY} message attribute: Missing stringValue/StringValue`);
+        }
+
+        const s3MessageKeyRegexMatch = s3MessageKey.match(/^\((.*)\)(.+)/);
+
         return {
-            bucketName: null,
-            s3MessageKey: null,
+            bucketName: s3MessageKeyRegexMatch[1],
+            s3MessageKey: s3MessageKeyRegexMatch[2],
         };
     }
 
-    const s3MessageKeyAttr = messageAttributes[S3_MESSAGE_BODY_KEY];
-    const s3MessageKey = s3MessageKeyAttr.stringValue || s3MessageKeyAttr.StringValue;
-
-    if (!s3MessageKey) {
-        throw new Error(`Invalid ${S3_MESSAGE_BODY_KEY} message attribute: Missing stringValue/StringValue`);
+    if (compatibleMode && (
+        messageAttributes[COMPATIBLE_ATTRIBUTE_NAME]
+        || (messageAttributes[COMPATIBLE_ATTRIBUTE_NAME_LEGACY])
+    )) {
+        let body;
+        try {
+            body = JSON.parse(message.Body);
+        }
+        catch (err) {
+            throw new Error(`Invalid message body: Cannot parse JSON for useS3 message`);
+        }
+        if (!(body.s3BucketName && body.s3Key)) {
+            throw new Error(`Invalid message body: Mising s3BucketName and/or s3Key`);
+        }
+        return {
+            bucketName: body.s3BucketName,
+            s3MessageKey: body.s3Key
+        };
     }
 
-    const s3MessageKeyRegexMatch = s3MessageKey.match(/^\((.*)\)(.+)/);
-
     return {
-        bucketName: s3MessageKeyRegexMatch[1],
-        s3MessageKey: s3MessageKeyRegexMatch[2],
+        bucketName: null,
+        s3MessageKey: null,
     };
 }
 
@@ -89,7 +111,16 @@ function getOriginReceiptHandle(receiptHandle) {
         : receiptHandle;
 }
 
-function addS3MessageKeyAttribute(s3MessageKey, attributes) {
+function addS3MessageKeyAttribute(s3MessageKey, attributes, messageBody, compatibleMode, use_legacy_attribute) {
+    if (compatibleMode) {
+        return {
+            ...attributes,
+            [use_legacy_attribute ? COMPATIBLE_ATTRIBUTE_NAME_LEGACY : COMPATIBLE_ATTRIBUTE_NAME]: {
+                DataType: 'Number',
+                StringValue: messageBody.length.toString()
+            }
+        };
+    }
     return {
         ...attributes,
         [S3_MESSAGE_BODY_KEY]: {
@@ -110,6 +141,11 @@ class ExtendedSqsClient {
         this.sendTransform =
             options.sendTransform || defaultSendTransform(options.alwaysUseS3, options.messageSizeThreshold);
         this.receiveTransform = options.receiveTransform || defaultReceiveTransform();
+
+         // Compatible with Amazon SQS Extended Client Library for Java
+         this.compatibleMode = options.compatibleMode || false;
+         // If True, all published messages use the Legacy reserved message attribute (SQSLargePayloadSize) instead of the current reserved message attribute (ExtendedPayloadSize).
+         this.use_legacy_attribute = options.use_legacy_attribute || false;
     }
 
     _storeS3Content(key, s3Content) {
@@ -146,7 +182,7 @@ class ExtendedSqsClient {
             before: async ({ event }) => {
                 await Promise.all(
                     event.Records.map(async (record) => {
-                        const { bucketName, s3MessageKey } = getS3MessageKeyAndBucket(record);
+                        const { bucketName, s3MessageKey } = getS3MessageKeyAndBucket(record, this.compatibleMode);
 
                         if (s3MessageKey) {
                             /* eslint-disable-next-line no-param-reassign */
@@ -254,11 +290,23 @@ class ExtendedSqsClient {
             s3MessageKey = uuidv4();
             sendParams.MessageAttributes = addS3MessageKeyAttribute(
                 `(${this.bucketName})${s3MessageKey}`,
-                sendParams.MessageAttributes
+                sendParams.MessageAttributes,
+                sendParams.MessageBody,
+                this.compatibleMode,
+                this.use_legacy_attribute
             );
-            sendParams.MessageBody = sendObj.messageBody || s3MessageKey;
+            if (this.compatibleMode) {
+                sendParams.MessageBody = JSON.stringify({
+                    s3BucketName: this.bucketName,
+                    s3Key: s3MessageKey
+                });
+            } else if (sendObj.messageBody) {
+                sendParams.MessageBody = sendObj.messageBody;
+            } else {
+                sendParams.MessageBody = s3MessageKey;
+            }
         }
-
+        
         return {
             s3MessageKey,
             sendParams,
@@ -312,7 +360,7 @@ class ExtendedSqsClient {
         const messages = await Promise.all(
             (response.Messages || []).map(async (input) => {
                 const message = { ...input };
-                const { bucketName, s3MessageKey } = getS3MessageKeyAndBucket(message);
+                const { bucketName, s3MessageKey } = getS3MessageKeyAndBucket(message, this.compatibleMode);
                 if (s3MessageKey) {
                     message.Body = this.receiveTransform(message, await this._getS3Content(bucketName, s3MessageKey));
                     message.ReceiptHandle = embedS3MarkersInReceiptHandle(
@@ -334,6 +382,9 @@ class ExtendedSqsClient {
             ...params,
             MessageAttributeNames: [...(params.MessageAttributeNames || []), ExtendedSqsClient.RESERVED_ATTRIBUTE_NAME],
         };
+        if (this.compatibleMode) {
+            modifiedParams.MessageAttributeNames.push(COMPATIBLE_ATTRIBUTE_NAME, COMPATIBLE_ATTRIBUTE_NAME_LEGACY);
+        }
         const receiveMessageCommand = new ReceiveMessageCommand(modifiedParams);
         const response = await this.sqsClient.send(receiveMessageCommand);
         return this._processReceive(response);


### PR DESCRIPTION
I've got a Node.js client that needs to interact with a server using Python. The equivalent Python library to this one https://github.com/awslabs/amazon-sqs-python-extended-client-lib/ and the Java client https://github.com/awslabs/amazon-sqs-java-extended-client-lib/ use a different format for messages using S3 to this Node.js client.

I've logged this as https://github.com/dvla/sqs-extended-client/issues/5

I've added an option compatibleMode which if set to true then....

For sendMessage it uses the Java format - with a numeric attribute ExtendedPayloadSize and the message body changed to a JSON object with the S3 bucket name and key - e.g.:

Attribute: ExtendedPayloadSize Number 424699
Body: {"s3BucketName": "bucket.name", "s3Key": "b03530d9-fae4-493b-a48e-3e1ea969bf1d"}

For receiveMessage it accepts either the original Node.js format or the Java format (and for Java format accepts either ExtendedPayloadSize or SQSLargePayloadSize as the flagging attrribute).

I've also added an option use_legacy_attribute for compatibility with older clients - if set uses the legacy reserved message attribute (SQSLargePayloadSize) instead of the current reserved message attribute (ExtendedPayloadSize) when sending.

With compatibleMode not set then the library behaves as before.

I've not added tests for these new options. Could do if pull request accepted.

This supersedes my earlier pull request #6. I'd be much obliged if you could merge this in.